### PR TITLE
Updates to workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,6 @@ jobs:
     - name: Use Node.js ${{ matrix.node_version }}
       uses: actions/setup-node@v1
       with:
-        version: ${{ matrix.node_version }}
+        node-version: ${{ matrix.node_version }}
     - name: Execute tests
       run: npm cit

--- a/.github/workflows/push_to_master.yml
+++ b/.github/workflows/push_to_master.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node_version }}
       uses: actions/setup-node@v1
       with:
-        version: ${{ matrix.node_version }}
+        node-version: ${{ matrix.node_version }}
     - name: Execute tests
       run: npm cit
 


### PR DESCRIPTION
`Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead.`